### PR TITLE
Updat code so running on CPU and TT hardware is possible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-torch==1.11.0
-torchvision>=0.9.1
 imageio
 imageio-ffmpeg
 matplotlib

--- a/run_nerf.py
+++ b/run_nerf.py
@@ -233,14 +233,29 @@ def create_nerf(args):
             model_fine.load_state_dict(ckpt['network_fine_state_dict'])
 
     ##########################
+    # Compile model on Forge FE
+    if args.tt:
+        import forge
 
+        sample_inputs = [torch.randn((args.netchunk, 90))]
+
+        tt_model = forge.compile(model, sample_inputs=sample_inputs)
+        tt_model_fine = forge.compile(model_fine, sample_inputs=sample_inputs)
+        
+        # Create function that will return tensor and not tuple
+        model_fn = lambda x: tt_model(x)[0]
+        model_fine_fn = lambda x: tt_model_fine(x)[0]
+    else:
+        model_fn = model
+        model_fine_fn = model_fine
+    
     render_kwargs_train = {
         'network_query_fn' : network_query_fn,
         'perturb' : args.perturb,
         'N_importance' : args.N_importance,
-        'network_fine' : model_fine,
+        'network_fine' : model_fine_fn,
         'N_samples' : args.N_samples,
-        'network_fn' : model,
+        'network_fn' : model_fn,
         'use_viewdirs' : args.use_viewdirs,
         'white_bkgd' : args.white_bkgd,
         'raw_noise_std' : args.raw_noise_std,
@@ -422,6 +437,7 @@ def config_parser():
 
     import configargparse
     parser = configargparse.ArgumentParser()
+    parser.add_argument('--tt', action='store_true', help='use forge-fe and tt hardware')
     parser.add_argument('--config', is_config_file=True, 
                         help='config file path')
     parser.add_argument("--expname", type=str, 
@@ -446,9 +462,9 @@ def config_parser():
                         help='learning rate')
     parser.add_argument("--lrate_decay", type=int, default=250, 
                         help='exponential learning rate decay (in 1000 steps)')
-    parser.add_argument("--chunk", type=int, default=1024*32, 
+    parser.add_argument("--chunk", type=int, default=1024*8, 
                         help='number of rays processed in parallel, decrease if running out of memory')
-    parser.add_argument("--netchunk", type=int, default=1024*64, 
+    parser.add_argument("--netchunk", type=int, default=1024*8, 
                         help='number of pts sent through network in parallel, decrease if running out of memory')
     parser.add_argument("--no_batching", action='store_true', 
                         help='only take random rays from 1 image at a time')

--- a/run_nerf.py
+++ b/run_nerf.py
@@ -222,7 +222,7 @@ def create_nerf(args):
     if len(ckpts) > 0 and not args.no_reload:
         ckpt_path = ckpts[-1]
         print('Reloading from', ckpt_path)
-        ckpt = torch.load(ckpt_path)
+        ckpt = torch.load(ckpt_path, map_location=torch.device("cpu"))
 
         start = ckpt['global_step']
         optimizer.load_state_dict(ckpt['optimizer_state_dict'])
@@ -873,6 +873,6 @@ def train():
 
 
 if __name__=='__main__':
-    torch.set_default_tensor_type('torch.cuda.FloatTensor')
+    # torch.set_default_tensor_type('torch.cuda.FloatTensor')
 
     train()


### PR DESCRIPTION
40 images in total are generated
Images are stored in `logs/blender_paper_lego/renderonly_path_200000`

## CPU
Command to run
```
python run_nerf.py --config configs/lego.txt --render_only --render_factor 2 --tt --netchunk 1024
```
render_factor:
=2 is 1/4 of the full image ~1 minute on cpu to execute per image

## TT device

Command to run
```
python run_nerf.py --config configs/lego.txt --render_only --render_factor 2 --tt --netchunk 1024
```
render_factor:
=2 is 1/4 of the full image ~8 minute on cpu to execute per image

## Notes

### Integral for rendering
Step that converts output of neural network 3D points to 2D pixel is done on cpu.
- [ ] Convert to torch module, and compile it

### Backward pass
In backward pass bwd op of concat is currently `select` op. This is decomposed into sparse matmul, I tried to swap `select` to index and it works when we also decompose index after autograd pass. But then fails because of some matmuls.

### Matmuls

General problem is assert in `/tt-metal/ttnn/cpp/ttnn/operations/matmul/device/matmul_op_multi_core_reuse_program_factory.cpp:279`

In that function is a note

```
    ////////////////////////////////////////////////////////////////////////////
    //                      Matmul Parameters Setup
    ////////////////////////////////////////////////////////////////////////////
    // NOTE: Only supports matmuls where output is blocks of 16 x 16 tiles (ie. multiples of 16*32 x 16*32)
    // NOTE: Maximum number of tiles in output is 120 * 16^2 = 30,720 (eg. [1, 1, 5120, 6144])
```

But if that is actualy the case we will have problem because every shape that is step of 2 between 2048 and 8192 dont work because of that end then 16384 dies because L1 cache limit 